### PR TITLE
Falta condición de que el A/C está funcionando

### DIFF
--- a/automation/limit_ac_temperature.yaml
+++ b/automation/limit_ac_temperature.yaml
@@ -37,6 +37,20 @@ blueprint:
       selector:
         entity:
           domain: counter
+
+    ac_running_sensor:
+      name: A/C Running Sensor
+      description: "Binary sensor that is 'on' while the A/C is actively running (optional). Prefer device_class 'running' or 'power'. Leave blank to ignore."
+      default: ""
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+              device_class: running
+            - domain: binary_sensor
+              device_class: power
+          multiple: false
+
     actions:
       name: Actions to perform
       description: "Actions to execute when threshold is crossed"
@@ -54,7 +68,11 @@ trigger:
     below: !input below_threshold
     above: !input above_threshold
 
-condition: []
+# Only run if the provided A/C running sensor is either blank or reporting 'on'.
+condition:
+  - condition: template
+    value_template: "{{ ac_running == '' or is_state(ac_running, 'on') }}"
+
 
 action:
   - if:

--- a/automation/limit_ac_temperature.yaml
+++ b/automation/limit_ac_temperature.yaml
@@ -60,6 +60,7 @@ variables:
   below_th: !input below_threshold
   above_th: !input above_threshold
   counter: !input ac_limited_counter
+  ac_running: !input ac_running_sensor
 
 trigger:
   - platform: numeric_state

--- a/automation/limit_ac_temperature.yaml
+++ b/automation/limit_ac_temperature.yaml
@@ -40,8 +40,7 @@ blueprint:
 
     ac_running_sensor:
       name: A/C Running Sensor
-      description: "Binary sensor that is 'on' while the A/C is actively running (optional). Prefer device_class 'running' or 'power'. Leave blank to ignore."
-      default: ""
+      description: "Binary sensor that is 'on' while the A/C is actively running"
       selector:
         entity:
           filter:
@@ -71,7 +70,7 @@ trigger:
 # Only run if the provided A/C running sensor is either blank or reporting 'on'.
 condition:
   - condition: template
-    value_template: "{{ ac_running == '' or is_state(ac_running, 'on') }}"
+    value_template: "{{ is_state(ac_running, 'on') }}"
 
 
 action:


### PR DESCRIPTION
Faltaba la condición de que el A/C está funcionando. Sin esto, puede llegar a triggerearse con el piso vacío si, por ejemplo, en verano supera el threshold superior