### PR TITLE
turn_off_ac_when_empty_lite.yaml debería incrementar el counter solo …

### DIFF
--- a/automation/turn_off_ac_when_empty_lite.yaml
+++ b/automation/turn_off_ac_when_empty_lite.yaml
@@ -47,6 +47,20 @@ blueprint:
           filter:
             - domain: counter
           multiple: false
+
+    ac_running_sensor:
+      name: A/C Running Sensor
+      description: "Binary sensor that is 'on' while the A/C is actively running (optional). Prefer device_class 'running' or 'power'. Leave blank to ignore."
+      default: ""
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+              device_class: running
+            - domain: binary_sensor
+              device_class: power
+          multiple: false
+
     google_sheet:
       name: Google Sheet (Optional)
       description: >-
@@ -55,6 +69,7 @@ blueprint:
       selector:
         config_entry:
           integration: google_sheets
+
     google_sheet_name:
       name: Google Sheet Name (Optional)
       description: >-
@@ -62,6 +77,7 @@ blueprint:
       selector:
         text:
       default: "log"
+
     turn_off_ac_action:
       name: Turn Off A/C Action
       description: >-
@@ -106,11 +122,16 @@ actions:
                 type: "OFF"
                 consumption: "-"
                 apartment: !input apartment_id
-      - action: counter.increment
-        metadata: {}
-        data: {}
-        target:
-          entity_id: !input ac_success_counter
+      - if:
+        - condition: template
+          value_template: "{{ ac_running_sensor != '' and is_state(ac_running_sensor, 'on')}}"
+        then: 
+          - action: counter.increment
+            metadata: {}
+            data: {}
+            target:
+              entity_id: !input ac_success_counter
+
   - alias: Not empty
     if:
       - condition: trigger


### PR DESCRIPTION
…si el aire estaba encendido

Cada vez que se ejecutaba la automatización se incrementaba el counter de apagado. Esto es incorrecto porque en muchas ocasiones el aire podía estar apagado. Agregué eso.